### PR TITLE
Made the AlamofireGlossError enum public

### DIFF
--- a/Source/Alamofire+Gloss.swift
+++ b/Source/Alamofire+Gloss.swift
@@ -8,7 +8,7 @@
 import Alamofire
 import Gloss
 
-enum AlamofireGlossError: Error {
+public enum AlamofireGlossError: Error {
   case jsonDecoding(rootCause: Any)
   case glossyInit(inputJson: JSON)
   case glossyArrayInit(inputJson: [JSON])


### PR DESCRIPTION
This way, clients of the library can use this value type in conditions.